### PR TITLE
Fix style tags

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -8,7 +8,7 @@ Author: conti
 Author URI: http://cntlog.net/
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Tags: one-column, two-columns, right-sidebar, flexible-header,
+Tags: one-column, two-columns, right-sidebar, flexible-header
 Version: 0.1
 */
 /*---------------------------------------------------------------------

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -8,7 +8,7 @@ Author: conti
 Author URI: http://cntlog.net/
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Tags: White, one-column, two-columns, right-sidebar, flexible-header,
+Tags: one-column, two-columns, right-sidebar, flexible-header,
 Version: 0.1
 */
 /*---------------------------------------------------------------------


### PR DESCRIPTION
The color has been removed from the tag list of the theme.
https://make.wordpress.org/themes/handbook/review/required/theme-tags/