### PR TITLE
allow wpcs

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,7 +1,17 @@
 <?php
-//Load CSS of parent theme and child theme
+/**
+ * Theme yuiyui's functions
+ *
+ * @package yuiyui
+ **/
+
+// Load CSS of parent theme and child theme.
 add_action( 'wp_enqueue_scripts', 'yuiyui_enqueue_styles' );
+
+/**
+ * Enqueue stylesheet.
+ **/
 function yuiyui_enqueue_styles() {
 	wp_enqueue_style( 'parent-style', path_join( get_template_directory_uri(), 'style.css' ) );
-	wp_enqueue_style( 'child-style', path_join( get_stylesheet_directory_uri(), 'style.css' ) , array('parent-style') );
+	wp_enqueue_style( 'child-style', path_join( get_stylesheet_directory_uri(), 'style.css' ) , array( 'parent-style' ) );
 }


### PR DESCRIPTION
Fix following things.

```
$ wpcs functions.php 

FILE: /var/www/html/wp-content/themes/wp-theme-yuiyui/functions.php
----------------------------------------------------------------------
FOUND 6 ERRORS AFFECTING 3 LINES
----------------------------------------------------------------------
 2 | ERROR | [ ] You must use "/**" style comments for a file comment
 2 | ERROR | [x] No space found before comment text; expected "//
   |       |     Load CSS of parent theme and child theme" but found
   |       |     "//Load CSS of parent theme and child theme"
 2 | ERROR | [ ] Inline comments must end in full-stops, exclamation
   |       |     marks, or question marks
 4 | ERROR | [ ] Missing function doc comment
 6 | ERROR | [x] Missing space after array opener.
 6 | ERROR | [x] Missing space before array closer.
----------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```